### PR TITLE
feature/add-to-UpNext-after-sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 7.78
 -----
-
+*   Updates
+    *   Deferred addition to UpNext post update after sync 
+        ([#3211](https://github.com/Automattic/pocket-casts-android/pull/312))
 
 7.77
 -----


### PR DESCRIPTION
## Description
Attempt to defer addition to UpNext these episodes that are new (post update) but might have been already finished, archived or added to UpNext on another device. The update of UpNext got extracted as a separate function, filter was added (potentially causing some slowdown as it would check if episodes aren't finished, archived or already on the UpNext list).
Must admit I'm not 100% sure that UpNext sync will always finish by the time we return from sync(), so if anything logic there might be slightly broken (still don't got into duplicated or missing items on UpNext after some testing)

Fixes #3211

## Testing Instructions
1. To test, you would need two devices, one setup to add episodes to UpNext (another that doesn't)
2. Make sure you have background refresh / update turned off.
3. On the device that doesn't sync, pick an episode that should be added to UpNext (sometimes it takes a while for that to happen) on the device adding to UpNext
4. Listen to that episode(s)
5. Open and observe UpNext syncing on 1st device - before fix it would put the episode on UpNext, download and in a while remove
6. Postfix episode doesn't show up on UpNext, doesn't download, is seen as archived / played

## Screenshots or Screencast
Need to get my head around how to create these.

## Checklist
- [X] If this is a user-facing change, I have added an entry in CHANGELOG.md
- [ ] Ensure the linter passes (`./gradlew spotlessApply` to automatically apply formatting/linting)
- [X] I have considered whether it makes sense to add tests for my changes
- [ ] All strings that need to be localized are in `modules/services/localization/src/main/res/values/strings.xml`
- [ ] Any jetpack compose components I added or changed are covered by compose previews
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.

#### I have tested any UI changes...
N/A
